### PR TITLE
feat(db): set up Supabase with initial schema

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,47 @@
+# Supabase Setup for GeoVoyager
+
+## Database Schema
+
+The GeoVoyager app uses Supabase for:
+- User authentication and profiles
+- Points of Interest (POIs) management
+- Tour creation and management
+- Live group sessions
+- Real-time updates for group features
+
+## Tables
+
+1. `profiles` - User profiles extending Supabase auth
+2. `pois` - Points of Interest with location data
+3. `tours` - Collections of POIs forming a tour
+4. `tour_pois` - Mapping of POIs to tours with sequence
+5. `group_sessions` - Live tour session management
+6. `session_participants` - Participants in group sessions
+
+## Setup Instructions
+
+1. Create a new Supabase project at https://app.supabase.com
+2. Get your project URL and anon key from Settings > API
+3. Run the initial migration:
+   ```bash
+   # From project root
+   supabase init
+   supabase link --project-ref your-project-ref
+   supabase db push
+   ```
+
+## Features
+
+- **Geofencing**: Using PostGIS for location-based queries
+- **Real-time**: Enabled for group sessions and participants
+- **RLS Policies**: Secure access control for all tables
+- **Automatic timestamps**: Created/updated timestamps for all tables
+
+## Environment Variables
+
+Add these to your `.env` file:
+```bash
+SUPABASE_URL=your-project-url
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+```

--- a/supabase/migrations/20250424133151_enable_extensions.sql
+++ b/supabase/migrations/20250424133151_enable_extensions.sql
@@ -1,0 +1,5 @@
+-- Enable required extensions
+create extension if not exists "uuid-ossp";
+create extension if not exists postgis;
+create extension if not exists postgis_topology;
+create extension if not exists earthdistance cascade;

--- a/supabase/migrations/20250424133152_initial_schema.sql
+++ b/supabase/migrations/20250424133152_initial_schema.sql
@@ -1,0 +1,159 @@
+-- Create users table (extends Supabase auth.users)
+create table public.profiles (
+  id uuid references auth.users primary key,
+  username text unique,
+  avatar_url text,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Create points of interest table
+create table public.pois (
+  id uuid primary key default uuid_generate_v4(),
+  title text not null,
+  description text,
+  latitude double precision not null,
+  longitude double precision not null,
+  audio_url text,
+  created_by uuid references public.profiles(id),
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Create tours table
+create table public.tours (
+  id uuid primary key default uuid_generate_v4(),
+  title text not null,
+  description text,
+  created_by uuid references public.profiles(id),
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Create tour_pois table for mapping POIs to tours with sequence
+create table public.tour_pois (
+  tour_id uuid references public.tours(id) on delete cascade,
+  poi_id uuid references public.pois(id) on delete cascade,
+  sequence_number integer not null,
+  primary key (tour_id, poi_id)
+);
+
+-- Create group_sessions table for live tours
+create table public.group_sessions (
+  id uuid primary key default uuid_generate_v4(),
+  tour_id uuid references public.tours(id),
+  leader_id uuid references public.profiles(id),
+  current_poi_id uuid references public.pois(id),
+  session_code text unique not null,
+  status text not null check (status in ('active', 'completed', 'cancelled')),
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  ended_at timestamp with time zone
+);
+
+-- Create session_participants table
+create table public.session_participants (
+  session_id uuid references public.group_sessions(id) on delete cascade,
+  user_id uuid references public.profiles(id) on delete cascade,
+  joined_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  left_at timestamp with time zone,
+  primary key (session_id, user_id)
+);
+
+-- Create RLS policies
+alter table public.profiles enable row level security;
+alter table public.pois enable row level security;
+alter table public.tours enable row level security;
+alter table public.tour_pois enable row level security;
+alter table public.group_sessions enable row level security;
+alter table public.session_participants enable row level security;
+
+-- Profiles policies
+create policy "Public profiles are viewable by everyone"
+  on public.profiles for select
+  using (true);
+
+create policy "Users can insert their own profile"
+  on public.profiles for insert
+  with check (auth.uid() = id);
+
+create policy "Users can update own profile"
+  on public.profiles for update
+  using (auth.uid() = id);
+
+-- POIs policies
+create policy "POIs are viewable by everyone"
+  on public.pois for select
+  using (true);
+
+create policy "Authenticated users can create POIs"
+  on public.pois for insert
+  with check (auth.role() = 'authenticated');
+
+create policy "POI creators can update their POIs"
+  on public.pois for update
+  using (auth.uid() = created_by);
+
+-- Tours policies
+create policy "Tours are viewable by everyone"
+  on public.tours for select
+  using (true);
+
+create policy "Authenticated users can create tours"
+  on public.tours for insert
+  with check (auth.role() = 'authenticated');
+
+create policy "Tour creators can update their tours"
+  on public.tours for update
+  using (auth.uid() = created_by);
+
+-- Create indexes for performance
+create index pois_location_idx on public.pois using gist (
+  ll_to_earth(latitude, longitude)
+);
+create index tour_pois_tour_id_idx on public.tour_pois(tour_id);
+create index tour_pois_sequence_idx on public.tour_pois(tour_id, sequence_number);
+create index group_sessions_code_idx on public.group_sessions(session_code);
+
+-- Create functions for geofencing
+create or replace function public.pois_within_radius(
+  lat double precision,
+  lng double precision,
+  radius_meters int
+) returns setof public.pois
+language sql
+as $$
+  select *
+  from public.pois
+  where earth_distance(
+    ll_to_earth(latitude, longitude),
+    ll_to_earth(lat, lng)
+  ) <= radius_meters;
+$$;
+
+-- Enable realtime subscriptions for group features
+alter publication supabase_realtime add table public.group_sessions;
+alter publication supabase_realtime add table public.session_participants;
+
+-- Trigger for updating timestamps
+create or replace function public.handle_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger handle_profiles_updated_at
+  before update on public.profiles
+  for each row
+  execute procedure public.handle_updated_at();
+
+create trigger handle_pois_updated_at
+  before update on public.pois
+  for each row
+  execute procedure public.handle_updated_at();
+
+create trigger handle_tours_updated_at
+  before update on public.tours
+  for each row
+  execute procedure public.handle_updated_at();


### PR DESCRIPTION
Closes #1

This PR sets up the initial Supabase database schema for GeoVoyager, including tables for users, POIs, and tours.

### Changes
- Enable PostGIS and UUID extensions
- Create tables:
  - `profiles` for user data
  - `pois` for Points of Interest
  - `tours` for tour management
  - Additional tables for group features
- Set up Row Level Security policies
- Add geofencing functionality
- Enable real-time subscriptions
- Add comprehensive documentation

### Testing Done
- ✅ Local Supabase instance started successfully
- ✅ Migrations applied without errors
- ✅ PostGIS extensions enabled
- ✅ Tables created with proper relationships

### Acceptance Criteria
- [x] Supabase tables created
- [x] Foreign keys and indexes set
- [x] Supabase project environment initialized